### PR TITLE
Add (optional) non-subdomain mode for when they are inaccessable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
 # Nertivia---Server
+To run Nertivia Server, please create the config.js and fb-fcm.json files, then run `node index.js`

--- a/index.js
+++ b/index.js
@@ -1,12 +1,15 @@
-app = require('./app');
+const app = require('./app');
+const config = require('./config.js');
 
-socketIO = require('./socketIO');
+const socketIO = require('./socketIO');
 
 const {http, io} = app;
 
-io.on('connection', socketIO);
+let mio = io;
+if(!config.domain) mio = mio.of("/nertivia");
+mio.on('connection', socketIO);
 
 
-http.listen(80, function(){
-    console.log('listening on *:80');
+http.listen(config.port||80, function(){
+    console.log("listening on *:"+config.port||80);
 });


### PR DESCRIPTION
First off, this should not affect existing server configs. This goes hand-in-hand with the PR to Nertivia-Client I've made ( https://github.com/supertiger1234/Nertivia-Client/pull/20 ), and allows users to flatten the subdomains into paths (e.g. `nertivia.`->`/nertivia`). It is necessary before I can make any more PRs to Nertivia-Client or Nertivia-Server.